### PR TITLE
Revert "[DOC] include descartes and rtree in `requirements_dev.txt`"

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,3 @@ nbconvert
 sphinx_bootstrap_theme
 sphinxcontrib-bibtex
 numpydoc
-descartes
-rtree


### PR DESCRIPTION
rtree not properly installing in readtehdocs